### PR TITLE
feat: add websocket server

### DIFF
--- a/codex-rs/Cargo.lock
+++ b/codex-rs/Cargo.lock
@@ -345,6 +345,64 @@ dependencies = [
 ]
 
 [[package]]
+name = "axum"
+version = "0.7.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edca88bc138befd0323b20752846e6587272d3b03b0343c8ea28a6f819e6e71f"
+dependencies = [
+ "async-trait",
+ "axum-core",
+ "base64 0.22.1",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "itoa",
+ "matchit",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustversion",
+ "serde",
+ "serde_json",
+ "serde_path_to_error",
+ "serde_urlencoded",
+ "sha1",
+ "sync_wrapper",
+ "tokio",
+ "tokio-tungstenite",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09f2bd6146b97ae3359fa0cc6d6b376d9539582c7b4220f041a33ec24c226199"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "rustversion",
+ "sync_wrapper",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
 name = "backtrace"
 version = "0.3.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -690,6 +748,7 @@ dependencies = [
  "codex-protocol",
  "codex-protocol-ts",
  "codex-tui",
+ "codex-web-server",
  "serde_json",
  "tokio",
  "tracing",
@@ -1007,6 +1066,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "codex-web-server"
+version = "0.0.0"
+dependencies = [
+ "anyhow",
+ "axum",
+ "clap",
+ "codex-common",
+ "codex-core",
+ "codex-login",
+ "futures",
+ "serde_json",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "color-eyre"
 version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1273,6 +1349,12 @@ dependencies = [
  "quote",
  "syn 2.0.104",
 ]
+
+[[package]]
+name = "data-encoding"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a2330da5de22e8a3cb63252ce2abb30116bf5265e89c0e01bc17015ce30a476"
 
 [[package]]
 name = "deadpool"
@@ -2836,6 +2918,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "matchit"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
+
+[[package]]
 name = "maybe-rayon"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4337,6 +4425,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_path_to_error"
+version = "0.1.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59fab13f937fa393d08645bf3a84bdfe86e296747b506ada67bb15f10f218b2a"
+dependencies = [
+ "itoa",
+ "serde",
+]
+
+[[package]]
 name = "serde_repr"
 version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5124,6 +5222,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-tungstenite"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edc5f74e248dc973e0dbb7b74c7e0d6fcc301c694ff50049504004ef4d0cdcd9"
+dependencies = [
+ "futures-util",
+ "log",
+ "tokio",
+ "tungstenite",
+]
+
+[[package]]
 name = "tokio-util"
 version = "0.7.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5235,6 +5345,7 @@ dependencies = [
  "tokio",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -5438,6 +5549,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "tungstenite"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18e5b8366ee7a95b16d32197d0b2604b43a0be89dc5fac9f8e96ccafbaedda8a"
+dependencies = [
+ "byteorder",
+ "bytes",
+ "data-encoding",
+ "http",
+ "httparse",
+ "log",
+ "rand 0.8.5",
+ "sha1",
+ "thiserror 1.0.69",
+ "utf-8",
+]
+
+[[package]]
 name = "typenum"
 version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5519,6 +5648,12 @@ name = "urlencoding"
 version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
+
+[[package]]
+name = "utf-8"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
 
 [[package]]
 name = "utf8_iter"

--- a/codex-rs/Cargo.toml
+++ b/codex-rs/Cargo.toml
@@ -18,6 +18,7 @@ members = [
     "protocol",
     "protocol-ts",
     "tui",
+    "web-server",
 ]
 resolver = "2"
 

--- a/codex-rs/cli/Cargo.toml
+++ b/codex-rs/cli/Cargo.toml
@@ -27,6 +27,7 @@ codex-login = { path = "../login" }
 codex-mcp-server = { path = "../mcp-server" }
 codex-protocol = { path = "../protocol" }
 codex-tui = { path = "../tui" }
+codex-web-server = { path = "../web-server" }
 serde_json = "1"
 tokio = { version = "1", features = [
     "io-std",

--- a/codex-rs/cli/src/main.rs
+++ b/codex-rs/cli/src/main.rs
@@ -15,6 +15,7 @@ use codex_cli::proto;
 use codex_common::CliConfigOverrides;
 use codex_exec::Cli as ExecCli;
 use codex_tui::Cli as TuiCli;
+use codex_web_server::WebCli;
 use std::path::PathBuf;
 
 use crate::proto::ProtoCli;
@@ -62,6 +63,9 @@ enum Subcommand {
     /// Run the Protocol stream via stdin/stdout
     #[clap(visible_alias = "p")]
     Proto(ProtoCli),
+
+    /// Run Codex as a WebSocket server.
+    Web(WebCli),
 
     /// Generate shell completion scripts.
     Completion(CompletionCommand),
@@ -183,6 +187,10 @@ async fn cli_main(codex_linux_sandbox_exe: Option<PathBuf>) -> anyhow::Result<()
         Some(Subcommand::Proto(mut proto_cli)) => {
             prepend_config_flags(&mut proto_cli.config_overrides, cli.config_overrides);
             proto::run_main(proto_cli).await?;
+        }
+        Some(Subcommand::Web(mut web_cli)) => {
+            prepend_config_flags(&mut web_cli.config_overrides, cli.config_overrides);
+            codex_web_server::run_main(web_cli).await?;
         }
         Some(Subcommand::Completion(completion_cli)) => {
             print_completion(completion_cli);

--- a/codex-rs/web-server/Cargo.toml
+++ b/codex-rs/web-server/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name = "codex-web-server"
+edition = "2024"
+version = { workspace = true }
+
+[lib]
+name = "codex_web_server"
+path = "src/lib.rs"
+
+[lints]
+workspace = true
+
+[dependencies]
+anyhow = "1"
+axum = { version = "0.7", features = ["ws"] }
+clap = { version = "4", features = ["derive"] }
+codex-common = { path = "../common", features = ["cli"] }
+codex-core = { path = "../core" }
+codex-login = { path = "../login" }
+serde_json = "1"
+tokio = { version = "1", features = ["macros", "rt-multi-thread", "signal"] }
+tracing = "0.1.41"
+tracing-subscriber = "0.3.19"
+futures = "0.3"
+

--- a/codex-rs/web-server/src/lib.rs
+++ b/codex-rs/web-server/src/lib.rs
@@ -1,0 +1,147 @@
+use std::net::SocketAddr;
+use std::sync::Arc;
+
+use anyhow::Result;
+use axum::Router;
+use axum::extract::WebSocketUpgrade;
+use axum::extract::ws::Message;
+use axum::extract::ws::WebSocket;
+use axum::routing::get;
+use clap::Parser;
+use codex_common::CliConfigOverrides;
+use codex_core::ConversationManager;
+use codex_core::NewConversation;
+use codex_core::config::Config;
+use codex_core::config::ConfigOverrides;
+use codex_core::protocol::Event;
+use codex_core::protocol::EventMsg;
+use codex_core::protocol::Submission;
+use codex_login::AuthManager;
+use futures::SinkExt;
+use futures::StreamExt;
+use tokio::net::TcpListener;
+use tracing::error;
+use tracing::info;
+
+#[derive(Debug, Parser)]
+pub struct WebCli {
+    #[clap(skip)]
+    pub config_overrides: CliConfigOverrides,
+
+    /// Address to bind the WebSocket server to
+    #[arg(long, default_value = "127.0.0.1:8080")]
+    pub addr: String,
+}
+
+pub async fn run_main(opts: WebCli) -> Result<()> {
+    tracing_subscriber::fmt()
+        .with_writer(std::io::stderr)
+        .init();
+
+    let WebCli {
+        config_overrides,
+        addr,
+    } = opts;
+    let overrides_vec = config_overrides
+        .parse_overrides()
+        .map_err(anyhow::Error::msg)?;
+
+    let config = Config::load_with_cli_overrides(overrides_vec, ConfigOverrides::default())?;
+    let conversation_manager = Arc::new(ConversationManager::new(AuthManager::shared(
+        config.codex_home.clone(),
+        config.preferred_auth_method,
+    )));
+    let config = Arc::new(config);
+
+    let app = Router::new().route(
+        "/ws",
+        get({
+            let manager = conversation_manager.clone();
+            let cfg = config.clone();
+            move |ws: WebSocketUpgrade| {
+                let manager = manager.clone();
+                let cfg = cfg.clone();
+                async move { ws.on_upgrade(move |socket| handle_socket(socket, manager, cfg)) }
+            }
+        }),
+    );
+
+    let addr: SocketAddr = addr.parse()?;
+    let listener = TcpListener::bind(addr).await?;
+    info!("Listening on {addr}");
+    axum::serve(listener, app).await?;
+    Ok(())
+}
+
+async fn handle_socket(
+    socket: WebSocket,
+    conversation_manager: Arc<ConversationManager>,
+    config: Arc<Config>,
+) {
+    let NewConversation {
+        conversation_id: _,
+        conversation,
+        session_configured,
+    } = match conversation_manager
+        .new_conversation((*config).clone())
+        .await
+    {
+        Ok(nc) => nc,
+        Err(e) => {
+            error!("failed to start conversation: {e:#}");
+            return;
+        }
+    };
+
+    let mut socket = socket;
+    let synthetic_event = Event {
+        id: "".to_string(),
+        msg: EventMsg::SessionConfigured(session_configured),
+    };
+    if let Ok(s) = serde_json::to_string(&synthetic_event)
+        && socket.send(Message::Text(s)).await.is_err() {
+            return;
+        }
+
+    let (mut sender, mut receiver) = socket.split();
+    let convo_for_incoming = conversation.clone();
+    let recv_task = tokio::spawn(async move {
+        while let Some(Ok(msg)) = receiver.next().await {
+            match msg {
+                Message::Text(text) => match serde_json::from_str::<Submission>(&text) {
+                    Ok(sub) => {
+                        if let Err(e) = convo_for_incoming.submit_with_id(sub).await {
+                            error!("{e:#}");
+                            break;
+                        }
+                    }
+                    Err(e) => error!("invalid submission: {e}"),
+                },
+                Message::Close(_) => break,
+                _ => {}
+            }
+        }
+    });
+
+    let convo_for_events = conversation;
+    let send_task = tokio::spawn(async move {
+        loop {
+            match convo_for_events.next_event().await {
+                Ok(event) => match serde_json::to_string(&event) {
+                    Ok(s) => {
+                        if sender.send(Message::Text(s)).await.is_err() {
+                            break;
+                        }
+                    }
+                    Err(e) => error!("Failed to serialize event: {e}"),
+                },
+                Err(e) => {
+                    error!("{e:#}");
+                    break;
+                }
+            }
+        }
+    });
+
+    let _ = tokio::join!(recv_task, send_task);
+}


### PR DESCRIPTION
## Summary
- add codex-web-server crate exposing ConversationManager over WebSocket
- wire up new web subcommand in CLI

## Testing
- `just fmt`
- `just fix -p codex-web-server`
- `just fix -p codex-cli`
- `cargo test -p codex-web-server`
- `cargo test -p codex-cli`


------
https://chatgpt.com/codex/tasks/task_b_68ad74021b2c8329a4657b15c465638e