### PR TITLE
feat: add session registry and RPC to web server

### DIFF
--- a/codex-rs/Cargo.lock
+++ b/codex-rs/Cargo.lock
@@ -1075,11 +1075,16 @@ dependencies = [
  "codex-common",
  "codex-core",
  "codex-login",
+ "codex-protocol",
  "futures",
+ "mcp-types",
+ "serde",
  "serde_json",
  "tokio",
+ "toml 0.9.5",
  "tracing",
  "tracing-subscriber",
+ "uuid",
 ]
 
 [[package]]

--- a/codex-rs/web-server/Cargo.toml
+++ b/codex-rs/web-server/Cargo.toml
@@ -17,9 +17,14 @@ clap = { version = "4", features = ["derive"] }
 codex-common = { path = "../common", features = ["cli"] }
 codex-core = { path = "../core" }
 codex-login = { path = "../login" }
+codex-protocol = { path = "../protocol" }
+mcp-types = { path = "../mcp-types" }
+serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+toml = "0.9"
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "signal"] }
 tracing = "0.1.41"
 tracing-subscriber = "0.3.19"
 futures = "0.3"
+uuid = { version = "1", features = ["serde", "v4"] }
 

--- a/codex-rs/web-server/src/lib.rs
+++ b/codex-rs/web-server/src/lib.rs
@@ -1,4 +1,6 @@
+use std::collections::HashMap;
 use std::net::SocketAddr;
+use std::path::PathBuf;
 use std::sync::Arc;
 
 use anyhow::Result;
@@ -13,15 +15,41 @@ use codex_core::ConversationManager;
 use codex_core::NewConversation;
 use codex_core::config::Config;
 use codex_core::config::ConfigOverrides;
-use codex_core::protocol::Event;
-use codex_core::protocol::EventMsg;
-use codex_core::protocol::Submission;
+use codex_core::protocol::InputItem as CoreInputItem;
+use codex_core::protocol::Op;
 use codex_login::AuthManager;
+use codex_protocol::mcp_protocol::AddConversationListenerParams;
+use codex_protocol::mcp_protocol::AddConversationSubscriptionResponse;
+use codex_protocol::mcp_protocol::ConversationId;
+use codex_protocol::mcp_protocol::InputItem as WireInputItem;
+use codex_protocol::mcp_protocol::InterruptConversationParams;
+use codex_protocol::mcp_protocol::InterruptConversationResponse;
+use codex_protocol::mcp_protocol::NewConversationParams;
+use codex_protocol::mcp_protocol::NewConversationResponse;
+use codex_protocol::mcp_protocol::RemoveConversationListenerParams;
+use codex_protocol::mcp_protocol::RemoveConversationSubscriptionResponse;
+use codex_protocol::mcp_protocol::SendUserMessageParams;
+use codex_protocol::mcp_protocol::SendUserMessageResponse;
+use codex_protocol::mcp_protocol::SendUserTurnParams;
+use codex_protocol::mcp_protocol::SendUserTurnResponse;
 use futures::SinkExt;
 use futures::StreamExt;
+use futures::stream::SplitSink;
+use mcp_types::JSONRPCError;
+use mcp_types::JSONRPCErrorError;
+use mcp_types::JSONRPCNotification;
+use mcp_types::JSONRPCRequest;
+use mcp_types::JSONRPCResponse;
+use mcp_types::RequestId;
+use serde::Deserialize;
+use serde::Serialize;
+use serde_json::json;
 use tokio::net::TcpListener;
+use tokio::sync::oneshot;
+use tokio::sync::Mutex;
 use tracing::error;
 use tracing::info;
+use uuid::Uuid;
 
 #[derive(Debug, Parser)]
 pub struct WebCli {
@@ -47,21 +75,18 @@ pub async fn run_main(opts: WebCli) -> Result<()> {
         .map_err(anyhow::Error::msg)?;
 
     let config = Config::load_with_cli_overrides(overrides_vec, ConfigOverrides::default())?;
-    let conversation_manager = Arc::new(ConversationManager::new(AuthManager::shared(
+    let conversation_manager = ConversationManager::new(AuthManager::shared(
         config.codex_home.clone(),
         config.preferred_auth_method,
-    )));
-    let config = Arc::new(config);
+    ));
 
     let app = Router::new().route(
         "/ws",
         get({
             let manager = conversation_manager.clone();
-            let cfg = config.clone();
             move |ws: WebSocketUpgrade| {
                 let manager = manager.clone();
-                let cfg = cfg.clone();
-                async move { ws.on_upgrade(move |socket| handle_socket(socket, manager, cfg)) }
+                async move { ws.on_upgrade(move |socket| handle_socket(socket, manager)) }
             }
         }),
     );
@@ -73,75 +98,462 @@ pub async fn run_main(opts: WebCli) -> Result<()> {
     Ok(())
 }
 
-async fn handle_socket(
-    socket: WebSocket,
-    conversation_manager: Arc<ConversationManager>,
-    config: Arc<Config>,
-) {
-    let NewConversation {
-        conversation_id: _,
-        conversation,
-        session_configured,
-    } = match conversation_manager
-        .new_conversation((*config).clone())
-        .await
-    {
-        Ok(nc) => nc,
-        Err(e) => {
-            error!("failed to start conversation: {e:#}");
-            return;
-        }
-    };
+#[derive(Deserialize)]
+struct CloseSessionParams {
+    conversation_id: ConversationId,
+}
 
-    let mut socket = socket;
-    let synthetic_event = Event {
-        id: "".to_string(),
-        msg: EventMsg::SessionConfigured(session_configured),
-    };
-    if let Ok(s) = serde_json::to_string(&synthetic_event)
-        && socket.send(Message::Text(s)).await.is_err() {
-            return;
-        }
+#[derive(Serialize)]
+struct ListSessionsResponse {
+    sessions: Vec<ConversationId>,
+}
 
-    let (mut sender, mut receiver) = socket.split();
-    let convo_for_incoming = conversation.clone();
-    let recv_task = tokio::spawn(async move {
-        while let Some(Ok(msg)) = receiver.next().await {
-            match msg {
-                Message::Text(text) => match serde_json::from_str::<Submission>(&text) {
-                    Ok(sub) => {
-                        if let Err(e) = convo_for_incoming.submit_with_id(sub).await {
-                            error!("{e:#}");
-                            break;
-                        }
-                    }
-                    Err(e) => error!("invalid submission: {e}"),
-                },
-                Message::Close(_) => break,
-                _ => {}
+async fn handle_socket(socket: WebSocket, conversation_manager: ConversationManager) {
+    let (sender, mut receiver) = socket.split();
+    let sender = Arc::new(Mutex::new(sender));
+    let mut listeners: HashMap<Uuid, oneshot::Sender<()>> = HashMap::new();
+
+    while let Some(Ok(msg)) = receiver.next().await {
+        if let Message::Text(text) = msg {
+            let Ok(req) = serde_json::from_str::<JSONRPCRequest>(&text) else {
+                continue;
+            };
+            let id = req.id.clone();
+
+            match req.method.as_str() {
+                "newConversation" => {
+                    let params: NewConversationParams = req
+                        .params
+                        .and_then(|v| serde_json::from_value(v).ok())
+                        .unwrap_or_default();
+                    handle_new_conversation(sender.clone(), &conversation_manager, id, params)
+                        .await;
+                }
+                "addConversationListener" => {
+                    let params: AddConversationListenerParams =
+                        match req.params.and_then(|v| serde_json::from_value(v).ok()) {
+                            Some(p) => p,
+                            None => {
+                                send_invalid_request(sender.clone(), id, "missing params").await;
+                                continue;
+                            }
+                        };
+                    handle_add_listener(
+                        sender.clone(),
+                        &conversation_manager,
+                        &mut listeners,
+                        id,
+                        params,
+                    )
+                    .await;
+                }
+                "removeConversationListener" => {
+                    let params: RemoveConversationListenerParams =
+                        match req.params.and_then(|v| serde_json::from_value(v).ok()) {
+                            Some(p) => p,
+                            None => {
+                                send_invalid_request(sender.clone(), id, "missing params").await;
+                                continue;
+                            }
+                        };
+                    handle_remove_listener(sender.clone(), &mut listeners, id, params).await;
+                }
+                "sendUserMessage" => {
+                    let params: SendUserMessageParams =
+                        match req.params.and_then(|v| serde_json::from_value(v).ok()) {
+                            Some(p) => p,
+                            None => {
+                                send_invalid_request(sender.clone(), id, "missing params").await;
+                                continue;
+                            }
+                        };
+                    handle_send_user_message(sender.clone(), &conversation_manager, id, params)
+                        .await;
+                }
+                "sendUserTurn" => {
+                    let params: SendUserTurnParams =
+                        match req.params.and_then(|v| serde_json::from_value(v).ok()) {
+                            Some(p) => p,
+                            None => {
+                                send_invalid_request(sender.clone(), id, "missing params").await;
+                                continue;
+                            }
+                        };
+                    handle_send_user_turn(sender.clone(), &conversation_manager, id, params).await;
+                }
+                "interruptConversation" => {
+                    let params: InterruptConversationParams =
+                        match req.params.and_then(|v| serde_json::from_value(v).ok()) {
+                            Some(p) => p,
+                            None => {
+                                send_invalid_request(sender.clone(), id, "missing params").await;
+                                continue;
+                            }
+                        };
+                    handle_interrupt(sender.clone(), &conversation_manager, id, params).await;
+                }
+                "listSessions" => {
+                    let ids = conversation_manager.list_conversations().await;
+                    let resp = ListSessionsResponse {
+                        sessions: ids.into_iter().map(ConversationId).collect(),
+                    };
+                    send_response(sender.clone(), id, resp).await;
+                }
+                "closeSession" => {
+                    let params: CloseSessionParams =
+                        match req.params.and_then(|v| serde_json::from_value(v).ok()) {
+                            Some(p) => p,
+                            None => {
+                                send_invalid_request(sender.clone(), id, "missing params").await;
+                                continue;
+                            }
+                        };
+                    let _ = conversation_manager
+                        .remove_conversation(params.conversation_id.0)
+                        .await;
+                    send_response(sender.clone(), id, json!({})).await;
+                }
+                _ => {
+                    send_invalid_request(sender.clone(), id, "method not found").await;
+                }
             }
         }
-    });
+    }
 
-    let convo_for_events = conversation;
-    let send_task = tokio::spawn(async move {
+    for (_, tx) in listeners {
+        let _ = tx.send(());
+    }
+}
+
+async fn handle_new_conversation(
+    sender: Arc<Mutex<SplitSink<WebSocket, Message>>>,
+    conversation_manager: &ConversationManager,
+    request_id: RequestId,
+    params: NewConversationParams,
+) {
+    let config = match derive_config_from_params(params) {
+        Ok(c) => c,
+        Err(err) => {
+            send_invalid_request(sender, request_id, &format!("error deriving config: {err}"))
+                .await;
+            return;
+        }
+    };
+
+    match conversation_manager.new_conversation(config).await {
+        Ok(NewConversation {
+            conversation_id,
+            session_configured,
+            ..
+        }) => {
+            let response = NewConversationResponse {
+                conversation_id: ConversationId(conversation_id),
+                model: session_configured.model,
+            };
+            send_response(sender, request_id, response).await;
+        }
+        Err(err) => {
+            send_invalid_request(
+                sender,
+                request_id,
+                &format!("error creating conversation: {err}"),
+            )
+            .await;
+        }
+    }
+}
+
+async fn handle_add_listener(
+    sender: Arc<Mutex<SplitSink<WebSocket, Message>>>,
+    conversation_manager: &ConversationManager,
+    listeners: &mut HashMap<Uuid, oneshot::Sender<()>>,
+    request_id: RequestId,
+    params: AddConversationListenerParams,
+) {
+    let AddConversationListenerParams { conversation_id } = params;
+    let Ok(conversation) = conversation_manager
+        .get_conversation(conversation_id.0)
+        .await
+    else {
+        send_invalid_request(
+            sender,
+            request_id,
+            &format!("conversation not found: {}", conversation_id.0),
+        )
+        .await;
+        return;
+    };
+
+    let subscription_id = Uuid::new_v4();
+    let (tx, mut rx) = oneshot::channel();
+    listeners.insert(subscription_id, tx);
+    let outgoing = sender.clone();
+    tokio::spawn(async move {
         loop {
-            match convo_for_events.next_event().await {
-                Ok(event) => match serde_json::to_string(&event) {
-                    Ok(s) => {
-                        if sender.send(Message::Text(s)).await.is_err() {
-                            break;
-                        }
+            tokio::select! {
+                _ = &mut rx => { break; }
+                evt = conversation.next_event() => {
+                    let event = match evt { Ok(e) => e, Err(err) => { error!("{err}"); break; } };
+                    let method = format!("codex/event/{}", event.msg);
+                    let mut params = match serde_json::to_value(event.clone()) {
+                        Ok(serde_json::Value::Object(map)) => map,
+                        _ => continue,
+                    };
+                    params.insert("conversationId".to_string(), conversation_id.to_string().into());
+                    let notification = JSONRPCNotification { jsonrpc: "2.0".to_string(), method, params: Some(params.into()) };
+                    if let Ok(text) = serde_json::to_string(&notification) {
+                        let mut guard = outgoing.lock().await;
+                        if guard.send(Message::Text(text)).await.is_err() { break; }
                     }
-                    Err(e) => error!("Failed to serialize event: {e}"),
-                },
-                Err(e) => {
-                    error!("{e:#}");
-                    break;
                 }
             }
         }
     });
 
-    let _ = tokio::join!(recv_task, send_task);
+    let response = AddConversationSubscriptionResponse { subscription_id };
+    send_response(sender, request_id, response).await;
+}
+
+async fn handle_remove_listener(
+    sender: Arc<Mutex<SplitSink<WebSocket, Message>>>,
+    listeners: &mut HashMap<Uuid, oneshot::Sender<()>>,
+    request_id: RequestId,
+    params: RemoveConversationListenerParams,
+) {
+    let RemoveConversationListenerParams { subscription_id } = params;
+    match listeners.remove(&subscription_id) {
+        Some(cancel) => {
+            let _ = cancel.send(());
+            let response = RemoveConversationSubscriptionResponse {};
+            send_response(sender, request_id, response).await;
+        }
+        None => {
+            send_invalid_request(
+                sender,
+                request_id,
+                &format!("subscription not found: {subscription_id}"),
+            )
+            .await;
+        }
+    }
+}
+
+async fn handle_send_user_message(
+    sender: Arc<Mutex<SplitSink<WebSocket, Message>>>,
+    conversation_manager: &ConversationManager,
+    request_id: RequestId,
+    params: SendUserMessageParams,
+) {
+    let SendUserMessageParams {
+        conversation_id,
+        items,
+    } = params;
+    let Ok(conversation) = conversation_manager
+        .get_conversation(conversation_id.0)
+        .await
+    else {
+        send_invalid_request(
+            sender,
+            request_id,
+            &format!("conversation not found: {conversation_id}"),
+        )
+        .await;
+        return;
+    };
+
+    let mapped: Vec<CoreInputItem> = items
+        .into_iter()
+        .map(|i| match i {
+            WireInputItem::Text { text } => CoreInputItem::Text { text },
+            WireInputItem::Image { image_url } => CoreInputItem::Image { image_url },
+            WireInputItem::LocalImage { path } => CoreInputItem::LocalImage { path },
+        })
+        .collect();
+
+    let _ = conversation.submit(Op::UserInput { items: mapped }).await;
+
+    let response = SendUserMessageResponse {};
+    send_response(sender, request_id, response).await;
+}
+
+async fn handle_send_user_turn(
+    sender: Arc<Mutex<SplitSink<WebSocket, Message>>>,
+    conversation_manager: &ConversationManager,
+    request_id: RequestId,
+    params: SendUserTurnParams,
+) {
+    let SendUserTurnParams {
+        conversation_id,
+        items,
+        cwd,
+        approval_policy,
+        sandbox_policy,
+        model,
+        effort,
+        summary,
+    } = params;
+    let Ok(conversation) = conversation_manager
+        .get_conversation(conversation_id.0)
+        .await
+    else {
+        send_invalid_request(
+            sender,
+            request_id,
+            &format!("conversation not found: {conversation_id}"),
+        )
+        .await;
+        return;
+    };
+
+    let mapped: Vec<CoreInputItem> = items
+        .into_iter()
+        .map(|i| match i {
+            WireInputItem::Text { text } => CoreInputItem::Text { text },
+            WireInputItem::Image { image_url } => CoreInputItem::Image { image_url },
+            WireInputItem::LocalImage { path } => CoreInputItem::LocalImage { path },
+        })
+        .collect();
+
+    let _ = conversation
+        .submit(Op::UserTurn {
+            items: mapped,
+            cwd,
+            approval_policy,
+            sandbox_policy,
+            model,
+            effort,
+            summary,
+        })
+        .await;
+
+    let response = SendUserTurnResponse {};
+    send_response(sender, request_id, response).await;
+}
+
+async fn handle_interrupt(
+    sender: Arc<Mutex<SplitSink<WebSocket, Message>>>,
+    conversation_manager: &ConversationManager,
+    request_id: RequestId,
+    params: InterruptConversationParams,
+) {
+    let InterruptConversationParams { conversation_id } = params;
+    let Ok(conversation) = conversation_manager
+        .get_conversation(conversation_id.0)
+        .await
+    else {
+        send_invalid_request(
+            sender,
+            request_id,
+            &format!("conversation not found: {conversation_id}"),
+        )
+        .await;
+        return;
+    };
+
+    let _ = conversation.submit(Op::Interrupt).await;
+    let response = InterruptConversationResponse {
+        abort_reason: codex_core::protocol::TurnAbortReason::Interrupted,
+    };
+    send_response(sender, request_id, response).await;
+}
+
+async fn send_response<T: Serialize>(
+    sender: Arc<Mutex<SplitSink<WebSocket, Message>>>,
+    id: RequestId,
+    result: T,
+) {
+    let response = JSONRPCResponse {
+        id,
+        jsonrpc: "2.0".to_string(),
+        result: serde_json::to_value(result).unwrap_or_default(),
+    };
+    if let Ok(text) = serde_json::to_string(&response) {
+        let mut guard = sender.lock().await;
+        let _ = guard.send(Message::Text(text)).await;
+    }
+}
+
+async fn send_invalid_request(
+    sender: Arc<Mutex<SplitSink<WebSocket, Message>>>,
+    id: RequestId,
+    message: &str,
+) {
+    let error = JSONRPCErrorError {
+        code: -32600,
+        message: message.to_string(),
+        data: None,
+    };
+    let response = JSONRPCError {
+        id,
+        jsonrpc: "2.0".to_string(),
+        error,
+    };
+    if let Ok(text) = serde_json::to_string(&response) {
+        let mut guard = sender.lock().await;
+        let _ = guard.send(Message::Text(text)).await;
+    }
+}
+
+fn json_to_toml(v: serde_json::Value) -> toml::Value {
+    match v {
+        serde_json::Value::Null => toml::Value::String(String::new()),
+        serde_json::Value::Bool(b) => toml::Value::Boolean(b),
+        serde_json::Value::Number(n) => {
+            if let Some(i) = n.as_i64() {
+                toml::Value::Integer(i)
+            } else if let Some(f) = n.as_f64() {
+                toml::Value::Float(f)
+            } else {
+                toml::Value::String(n.to_string())
+            }
+        }
+        serde_json::Value::String(s) => toml::Value::String(s),
+        serde_json::Value::Array(arr) => {
+            toml::Value::Array(arr.into_iter().map(json_to_toml).collect())
+        }
+        serde_json::Value::Object(map) => {
+            let tbl = map
+                .into_iter()
+                .map(|(k, v)| (k, json_to_toml(v)))
+                .collect::<toml::value::Table>();
+            toml::Value::Table(tbl)
+        }
+    }
+}
+
+fn derive_config_from_params(params: NewConversationParams) -> std::io::Result<Config> {
+    let NewConversationParams {
+        model,
+        profile,
+        cwd,
+        approval_policy,
+        sandbox: sandbox_mode,
+        config: cli_overrides,
+        base_instructions,
+        include_plan_tool,
+        include_apply_patch_tool,
+    } = params;
+    let overrides = ConfigOverrides {
+        model,
+        config_profile: profile,
+        cwd: cwd.map(PathBuf::from),
+        approval_policy,
+        sandbox_mode,
+        model_provider: None,
+        codex_linux_sandbox_exe: None,
+        base_instructions,
+        include_plan_tool,
+        include_apply_patch_tool,
+        disable_response_storage: None,
+        show_raw_agent_reasoning: None,
+        tools_web_search_request: None,
+    };
+
+    let cli_overrides = cli_overrides
+        .unwrap_or_default()
+        .into_iter()
+        .map(|(k, v)| (k, json_to_toml(v)))
+        .collect();
+
+    Config::load_with_cli_overrides(cli_overrides, overrides)
 }


### PR DESCRIPTION
## Summary
- share ConversationManager across connections
- extend web server with JSON-RPC API for conversations
- track sessions by conversation id and allow listing/closing

## Testing
- `just fix -p codex-core`
- `just fix -p codex-web-server`
- `cargo test -p codex-core` *(partial: integration tests exceeded timeout)*
- `cargo test -p codex-web-server`
- `cargo test --all-features` *(interrupted after compile)*

------
https://chatgpt.com/codex/tasks/task_b_68ad78aa6a7c8329aee2207918243d5c