### PR TITLE
feat: support workspace paths for new sessions

### DIFF
--- a/codex-rs/mcp-server/src/codex_message_processor.rs
+++ b/codex-rs/mcp-server/src/codex_message_processor.rs
@@ -721,6 +721,7 @@ fn derive_config_from_params(
         approval_policy,
         sandbox: sandbox_mode,
         config: cli_overrides,
+        workspace_paths,
         base_instructions,
         include_plan_tool,
         include_apply_patch_tool,
@@ -741,8 +742,19 @@ fn derive_config_from_params(
         tools_web_search_request: None,
     };
 
+    let mut cli_overrides = cli_overrides.unwrap_or_default();
+    if let Some(paths) = workspace_paths {
+        let arr = paths
+            .into_iter()
+            .map(|p| serde_json::Value::String(p.to_string_lossy().into_owned()))
+            .collect();
+        cli_overrides.insert(
+            "sandbox_workspace_write.writable_roots".into(),
+            serde_json::Value::Array(arr),
+        );
+    }
+
     let cli_overrides = cli_overrides
-        .unwrap_or_default()
         .into_iter()
         .map(|(k, v)| (k, json_to_toml(v)))
         .collect();

--- a/codex-rs/protocol/src/mcp_protocol.rs
+++ b/codex-rs/protocol/src/mcp_protocol.rs
@@ -133,6 +133,11 @@ pub struct NewConversationParams {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub config: Option<HashMap<String, serde_json::Value>>,
 
+    /// Additional filesystem paths to treat as writable when using
+    /// `sandbox = workspace-write`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub workspace_paths: Option<Vec<PathBuf>>,
+
     /// The set of instructions to use instead of the default ones.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub base_instructions: Option<String>,


### PR DESCRIPTION
## Summary
- allow providing workspace paths when creating a new session
- propagate workspace paths into Config overrides for sandbox writable roots
- accept workspace paths via the WebSocket API

## Testing
- `cargo test -p codex-mcp-server`
- `cargo test -p codex-web-server`
- `cargo test --all-features --no-run` *(fails: interrupted due to time)*

------
https://chatgpt.com/codex/tasks/task_b_68adb1ff7f4c8329968fdd3965459656