### PR TITLE
docs: add Web UI setup guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@
 - [Memory & project docs](#memory--project-docs)
 - [Non-interactive / CI mode](#non-interactive--ci-mode)
 - [Model Context Protocol (MCP)](#model-context-protocol-mcp)
+- [Web UI](#web-ui)
 - [Tracing / verbose logging](#tracing--verbose-logging)
   - [DotSlash](#dotslash)
 - [Configuration](#configuration)
@@ -470,6 +471,10 @@ env = { "API_KEY" = "value" }
 
 > [!TIP]
 > It is somewhat experimental, but the Codex CLI can also be run as an MCP _server_ via `codex mcp`. If you launch it with an MCP client such as `npx @modelcontextprotocol/inspector codex mcp` and send it a `tools/list` request, you will see that there is only one tool, `codex`, that accepts a grab-bag of inputs, including a catch-all `config` map for anything you might want to override. Feel free to play around with it and provide feedback via GitHub issues.
+
+## Web UI
+
+An experimental browser interface is available. See [docs/web-ui.md](docs/web-ui.md) for instructions on starting the WebSocket-enabled CLI and serving the Flutter app.
 
 ## Tracing / verbose logging
 

--- a/docs/web-ui.md
+++ b/docs/web-ui.md
@@ -1,0 +1,26 @@
+# Web UI
+
+The Codex Web UI is an experimental Flutter front end that connects to the CLI over WebSockets.
+
+## Start the WebSocket CLI
+
+Set your API key and launch the CLI in WebSocket mode:
+
+```bash
+export OPENAI_API_KEY="your-api-key-here"
+codex web --addr 127.0.0.1:8080
+```
+
+This starts a server on `ws://127.0.0.1:8080/ws`. Use `--addr` to change the host or port.
+
+## Build and serve the Flutter app
+
+From the repository root:
+
+```bash
+cd web-ui
+flutter build web
+flutter run -d web-server --web-port 8081
+```
+
+`flutter build web` creates a static bundle under `build/web`. `flutter run` serves it locally so you can visit the printed URL in your browser. The app expects to reach the CLI at the WebSocket URL shown above.


### PR DESCRIPTION
## Summary
- document how to start the CLI in WebSocket mode and build/serve the Flutter Web UI
- add Web UI section in README linking to the new guide

## Testing
- `pnpm format`
- `npx prettier docs/web-ui.md --check`


------
https://chatgpt.com/codex/tasks/task_b_68aea5b1d60c83298d16be99e6d9fdf7