### PR TITLE
feat(web-ui): add responsive layout and theme settings

### DIFF
--- a/web-ui/lib/main.dart
+++ b/web-ui/lib/main.dart
@@ -13,50 +13,125 @@ void main() {
 class MyApp extends StatelessWidget {
   MyApp({super.key, WebSocketService? service})
       : service =
-            service ?? (WebSocketService()..connect('ws://localhost:8080/ws'));
+            service ?? (WebSocketService()..connect('ws://localhost:8080/ws')),
+        themeMode = ValueNotifier(ThemeMode.system),
+        seedColor = ValueNotifier(Colors.blue);
 
   final WebSocketService service;
+  final ValueNotifier<ThemeMode> themeMode;
+  final ValueNotifier<Color> seedColor;
 
   @override
   Widget build(BuildContext context) {
-    return MaterialApp(
-      title: 'Codex UI',
-      theme: ThemeData(useMaterial3: true),
-      home: HomePage(service: service),
+    return ValueListenableBuilder<ThemeMode>(
+      valueListenable: themeMode,
+      builder: (context, mode, _) {
+        return ValueListenableBuilder<Color>(
+          valueListenable: seedColor,
+          builder: (context, color, __) {
+            return MaterialApp(
+              title: 'Codex UI',
+              theme: ThemeData(
+                colorSchemeSeed: color,
+                useMaterial3: true,
+              ),
+              darkTheme: ThemeData(
+                colorSchemeSeed: color,
+                brightness: Brightness.dark,
+                useMaterial3: true,
+              ),
+              themeMode: mode,
+              home: HomePage(
+                service: service,
+                themeMode: themeMode,
+                seedColor: seedColor,
+              ),
+            );
+          },
+        );
+      },
     );
   }
 }
 
-class HomePage extends StatelessWidget {
-  const HomePage({super.key, required this.service});
+class HomePage extends StatefulWidget {
+  const HomePage(
+      {super.key,
+      required this.service,
+      required this.themeMode,
+      required this.seedColor});
 
   final WebSocketService service;
+  final ValueNotifier<ThemeMode> themeMode;
+  final ValueNotifier<Color> seedColor;
+
+  @override
+  State<HomePage> createState() => _HomePageState();
+}
+
+class _HomePageState extends State<HomePage> {
+  int index = 0;
+
+  late final pages = <Widget>[
+    SessionListView(service: widget.service),
+    ChatView(service: widget.service),
+    const WorkspacePickerView(),
+    SettingsPanel(
+      service: widget.service,
+      themeMode: widget.themeMode,
+      seedColor: widget.seedColor,
+    ),
+  ];
 
   @override
   Widget build(BuildContext context) {
-    return DefaultTabController(
-      length: 4,
-      child: Scaffold(
-        appBar: AppBar(
-          title: const Text('Codex UI'),
-          bottom: const TabBar(
-            tabs: [
-              Tab(text: 'Sessions'),
-              Tab(text: 'Chat'),
-              Tab(text: 'Workspace'),
-              Tab(text: 'Settings'),
-            ],
-          ),
-        ),
-        body: TabBarView(
-          children: [
-            SessionListView(service: service),
-            ChatView(service: service),
-            const WorkspacePickerView(),
-            SettingsPanel(service: service),
-          ],
-        ),
-      ),
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        if (constraints.maxWidth >= 800) {
+          return Scaffold(
+            body: Row(
+              children: [
+                NavigationRail(
+                  selectedIndex: index,
+                  onDestinationSelected: (i) => setState(() => index = i),
+                  labelType: NavigationRailLabelType.all,
+                  destinations: const [
+                    NavigationRailDestination(
+                        icon: Icon(Icons.list), label: Text('Sessions')),
+                    NavigationRailDestination(
+                        icon: Icon(Icons.chat), label: Text('Chat')),
+                    NavigationRailDestination(
+                        icon: Icon(Icons.folder_open),
+                        label: Text('Workspace')),
+                    NavigationRailDestination(
+                        icon: Icon(Icons.settings), label: Text('Settings')),
+                  ],
+                ),
+                Expanded(child: pages[index]),
+              ],
+            ),
+          );
+        } else {
+          return Scaffold(
+            appBar: AppBar(title: const Text('Codex UI')),
+            body: pages[index],
+            bottomNavigationBar: BottomNavigationBar(
+              currentIndex: index,
+              onTap: (i) => setState(() => index = i),
+              items: const [
+                BottomNavigationBarItem(
+                    icon: Icon(Icons.list), label: 'Sessions'),
+                BottomNavigationBarItem(
+                    icon: Icon(Icons.chat), label: 'Chat'),
+                BottomNavigationBarItem(
+                    icon: Icon(Icons.folder_open), label: 'Workspace'),
+                BottomNavigationBarItem(
+                    icon: Icon(Icons.settings), label: 'Settings'),
+              ],
+            ),
+          );
+        }
+      },
     );
   }
 }

--- a/web-ui/lib/views/settings_panel.dart
+++ b/web-ui/lib/views/settings_panel.dart
@@ -4,9 +4,15 @@ import '../models/protocol.dart';
 import '../services/websocket_service.dart';
 
 class SettingsPanel extends StatefulWidget {
-  const SettingsPanel({super.key, required this.service});
+  const SettingsPanel(
+      {super.key,
+      required this.service,
+      required this.themeMode,
+      required this.seedColor});
 
   final WebSocketService service;
+  final ValueNotifier<ThemeMode> themeMode;
+  final ValueNotifier<Color> seedColor;
 
   @override
   State<SettingsPanel> createState() => _SettingsPanelState();
@@ -14,6 +20,12 @@ class SettingsPanel extends StatefulWidget {
 
 class _SettingsPanelState extends State<SettingsPanel> {
   final fields = <String, TextEditingController>{};
+  static const colorOptions = <String, Color>{
+    'Blue': Colors.blue,
+    'Green': Colors.green,
+    'Red': Colors.red,
+    'Purple': Colors.purple,
+  };
 
   @override
   void initState() {
@@ -32,9 +44,40 @@ class _SettingsPanelState extends State<SettingsPanel> {
 
   @override
   Widget build(BuildContext context) {
-    return ListView(
-      padding: const EdgeInsets.all(8),
-      children: fields.entries
+    final List<Widget> children = [
+      ValueListenableBuilder<ThemeMode>(
+        valueListenable: widget.themeMode,
+        builder: (context, mode, _) {
+          return DropdownButtonFormField<ThemeMode>(
+            value: mode,
+            decoration: const InputDecoration(labelText: 'Theme'),
+            onChanged: (m) {
+              if (m != null) widget.themeMode.value = m;
+            },
+            items: ThemeMode.values
+                .map((m) => DropdownMenuItem(value: m, child: Text(m.name)))
+                .toList(),
+          );
+        },
+      ),
+      const SizedBox(height: 8),
+      ValueListenableBuilder<Color>(
+        valueListenable: widget.seedColor,
+        builder: (context, color, _) {
+          return DropdownButtonFormField<Color>(
+            value: color,
+            decoration: const InputDecoration(labelText: 'Accent color'),
+            onChanged: (c) {
+              if (c != null) widget.seedColor.value = c;
+            },
+            items: colorOptions.entries
+                .map((e) => DropdownMenuItem(value: e.value, child: Text(e.key)))
+                .toList(),
+          );
+        },
+      ),
+      const Divider(),
+      ...fields.entries
           .map(
             (e) => Padding(
               padding: const EdgeInsets.symmetric(vertical: 4),
@@ -45,6 +88,8 @@ class _SettingsPanelState extends State<SettingsPanel> {
             ),
           )
           .toList(),
-    );
+    ];
+
+    return ListView(padding: const EdgeInsets.all(8), children: children);
   }
 }

--- a/web-ui/test/widget_test.dart
+++ b/web-ui/test/widget_test.dart
@@ -5,9 +5,12 @@ import 'package:web_ui/main.dart';
 import 'package:web_ui/services/websocket_service.dart';
 
 void main() {
-  testWidgets('App builds with tabs', (WidgetTester tester) async {
+  testWidgets('App builds with navigation', (WidgetTester tester) async {
+    tester.binding.window.physicalSizeTestValue = const Size(400, 800);
+    addTearDown(() => tester.binding.window.clearPhysicalSizeTestValue());
+
     await tester.pumpWidget(MyApp(service: WebSocketService()));
-    expect(find.byType(TabBar), findsOneWidget);
+    expect(find.byType(BottomNavigationBar), findsOneWidget);
     expect(find.text('Sessions'), findsOneWidget);
     expect(find.text('Chat'), findsOneWidget);
   });


### PR DESCRIPTION
## Summary
- make web UI responsive with NavigationRail for wide screens and bottom navigation for narrow screens
- add theme and accent color settings for customizable appearance
- adjust widget test for new navigation

## Testing
- `flutter format lib test` *(fails: command not found)*
- `dart format lib test` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68aea99c24608329843c79425349b99f