### PR TITLE
feat(core): add voice transcription and synthesis utilities

### DIFF
--- a/codex-rs/Cargo.lock
+++ b/codex-rs/Cargo.lock
@@ -3952,6 +3952,7 @@ dependencies = [
  "js-sys",
  "log",
  "mime",
+ "mime_guess",
  "native-tls",
  "percent-encoding",
  "pin-project-lite",

--- a/codex-rs/core/Cargo.toml
+++ b/codex-rs/core/Cargo.toml
@@ -32,7 +32,7 @@ os_info = "3.12.0"
 portable-pty = "0.9.0"
 rand = "0.9"
 regex-lite = "0.1.6"
-reqwest = { version = "0.12", features = ["json", "stream"] }
+reqwest = { version = "0.12", features = ["json", "stream", "multipart"] }
 serde = { version = "1", features = ["derive"] }
 serde_bytes = "0.11"
 serde_json = "1"

--- a/codex-rs/core/src/client.rs
+++ b/codex-rs/core/src/client.rs
@@ -63,9 +63,9 @@ struct Error {
 #[derive(Debug, Clone)]
 pub struct ModelClient {
     config: Arc<Config>,
-    auth_manager: Option<Arc<AuthManager>>,
-    client: reqwest::Client,
-    provider: ModelProviderInfo,
+    pub(crate) auth_manager: Option<Arc<AuthManager>>,
+    pub(crate) client: reqwest::Client,
+    pub(crate) provider: ModelProviderInfo,
     session_id: Uuid,
     effort: ReasoningEffortConfig,
     summary: ReasoningSummaryConfig,

--- a/codex-rs/core/src/lib.rs
+++ b/codex-rs/core/src/lib.rs
@@ -56,6 +56,7 @@ pub mod turn_diff_tracker;
 pub mod user_agent;
 mod user_notification;
 pub mod util;
+pub mod voice;
 pub use apply_patch::CODEX_APPLY_PATCH_ARG1;
 pub use safety::get_platform_sandbox;
 // Re-export the protocol types from the standalone `codex-protocol` crate so existing

--- a/codex-rs/core/src/voice.rs
+++ b/codex-rs/core/src/voice.rs
@@ -1,0 +1,61 @@
+use crate::client::ModelClient;
+use crate::error::{CodexErr, Result};
+use reqwest::multipart;
+use serde::Deserialize;
+use serde_json::json;
+
+impl ModelClient {
+    /// Transcribe audio bytes to text using OpenAI's Whisper model.
+    pub async fn transcribe_audio(&self, audio: &[u8], mime_type: &str) -> Result<String> {
+        let auth_mode = self.auth_manager.as_ref().and_then(|m| m.auth());
+        let builder = self
+            .provider
+            .create_request_builder_for_path(&self.client, &auth_mode, "/audio/transcriptions")
+            .await?;
+
+        let part = multipart::Part::bytes(audio.to_vec())
+            .file_name("audio")
+            .mime_str(mime_type)?;
+        let form = multipart::Form::new()
+            .text("model", "whisper-1")
+            .part("file", part);
+        let resp = builder.multipart(form).send().await?;
+        if !resp.status().is_success() {
+            let status = resp.status();
+            let body = resp.text().await.unwrap_or_default();
+            return Err(CodexErr::UnexpectedStatus(status, body));
+        }
+        #[derive(Deserialize)]
+        struct Transcription {
+            text: String,
+        }
+        let t: Transcription = resp.json().await?;
+        Ok(t.text)
+    }
+
+    /// Convert text to spoken audio using GPT-4o TTS models.
+    pub async fn synthesize_speech(&self, text: &str, voice: &str) -> Result<Vec<u8>> {
+        let auth_mode = self.auth_manager.as_ref().and_then(|m| m.auth());
+        let builder = self
+            .provider
+            .create_request_builder_for_path(&self.client, &auth_mode, "/audio/speech")
+            .await?;
+        let payload = json!({
+            "model": "gpt-4o-mini-tts",
+            "input": text,
+            "voice": voice,
+        });
+        let resp = builder
+            .header("Accept", "audio/mpeg")
+            .json(&payload)
+            .send()
+            .await?;
+        if !resp.status().is_success() {
+            let status = resp.status();
+            let body = resp.text().await.unwrap_or_default();
+            return Err(CodexErr::UnexpectedStatus(status, body));
+        }
+        let bytes = resp.bytes().await?;
+        Ok(bytes.to_vec())
+    }
+}


### PR DESCRIPTION
## Summary
- support OpenAI audio endpoints for transcription and speech generation
- expose voice helpers through new core module
- enable multipart requests and request builders for arbitrary API paths

## Testing
- `cargo test -p codex-core`


------
https://chatgpt.com/codex/tasks/task_b_68b1387fa7408329a17d1b5d6b1d0f07