### PR TITLE
chore: add python virtual environment setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,6 +49,7 @@ yarn-error.log*
 # env
 .env*
 !.env.example
+.venv/
 
 # package
 *.tgz

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -34,7 +34,7 @@ name = "complex_math"
 [mcp]
 # Program to launch (bare name on PATH, absolute path, or relative to the plugin folder)
 command = "python"
-args = ["server.py"]
+args = ["run.py"]
 
 # Optional environment for the process
 # env = { PYTHONUNBUFFERED = "1" }
@@ -65,6 +65,8 @@ Folder layout:
 plugins/
   complex_math/
     plugin.toml
+    requirements.txt
+    run.py
     server.py
 ```
 
@@ -75,10 +77,10 @@ name = "complex_math"
 
 [mcp]
 command = "python"
-args = ["server.py"]
+args = ["run.py"]
 ```
 
-`server.py` is a small, dependency‑free JSON‑RPC MCP server. It:
+`run.py` bootstraps a virtual environment using `requirements.txt` and then executes `server.py`, a small, dependency‑free JSON‑RPC MCP server. `server.py`:
 
 - Responds to `initialize` with `tools` capability
 - Implements `tools/list` with the schemas above

--- a/plugins/complex_math/plugin.toml
+++ b/plugins/complex_math/plugin.toml
@@ -2,5 +2,5 @@ name = "complex_math"
 
 [mcp]
 command = "python"
-args = ["server.py"]
+args = ["run.py"]
 

--- a/plugins/complex_math/requirements.txt
+++ b/plugins/complex_math/requirements.txt
@@ -1,0 +1,2 @@
+# Python dependencies for the complex_math plugin
+# This plugin currently relies only on the Python standard library.

--- a/plugins/complex_math/run.py
+++ b/plugins/complex_math/run.py
@@ -1,0 +1,24 @@
+#!/usr/bin/env python3
+"""Bootstrap a virtual environment and run the complex_math server."""
+import os
+import subprocess
+import sys
+
+HERE = os.path.abspath(os.path.dirname(__file__))
+VENV_DIR = os.path.join(HERE, '.venv')
+
+if not os.path.exists(VENV_DIR):
+    subprocess.check_call([sys.executable, '-m', 'venv', VENV_DIR])
+    if os.name == 'nt':
+        pip_cmd = os.path.join(VENV_DIR, 'Scripts', 'pip.exe')
+    else:
+        pip_cmd = os.path.join(VENV_DIR, 'bin', 'pip')
+    subprocess.check_call([pip_cmd, 'install', '--upgrade', 'pip'])
+    subprocess.check_call([pip_cmd, 'install', '-r', os.path.join(HERE, 'requirements.txt')])
+
+if os.name == 'nt':
+    python = os.path.join(VENV_DIR, 'Scripts', 'python.exe')
+else:
+    python = os.path.join(VENV_DIR, 'bin', 'python')
+
+os.execv(python, [python, os.path.join(HERE, 'server.py')])

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+# Python dependencies for repository scripts
+# These scripts currently rely only on the Python standard library.

--- a/scripts/setup_venv.py
+++ b/scripts/setup_venv.py
@@ -1,0 +1,19 @@
+#!/usr/bin/env python3
+"""Create a local Python virtual environment and install requirements."""
+import os
+import subprocess
+import sys
+
+VENV_DIR = os.path.join(os.path.dirname(__file__), '..', '.venv')
+VENV_DIR = os.path.abspath(VENV_DIR)
+
+if not os.path.exists(VENV_DIR):
+    subprocess.check_call([sys.executable, '-m', 'venv', VENV_DIR])
+
+if os.name == 'nt':
+    pip_executable = os.path.join(VENV_DIR, 'Scripts', 'pip.exe')
+else:
+    pip_executable = os.path.join(VENV_DIR, 'bin', 'pip')
+
+subprocess.check_call([pip_executable, 'install', '--upgrade', 'pip'])
+subprocess.check_call([pip_executable, 'install', '-r', os.path.join(os.path.dirname(__file__), '..', 'requirements.txt')])


### PR DESCRIPTION
## Summary
- add repository-wide `requirements.txt` and venv bootstrap script
- make complex_math plugin bootstrap its own virtual environment
- document plugin requirements and ignore local `.venv` directories

## Testing
- `python -m py_compile plugins/complex_math/run.py plugins/complex_math/server.py scripts/setup_venv.py`
- `python scripts/setup_venv.py`
- `python scripts/asciicheck.py docs/plugins.md` *(fails: invalid characters)*

------
https://chatgpt.com/codex/tasks/task_b_68b1b4f55054832985faa88fec6927a5