### PR TITLE
feat: add API key rotation for providers

### DIFF
--- a/codex-rs/core/src/codex.rs
+++ b/codex-rs/core/src/codex.rs
@@ -1605,6 +1605,9 @@ async fn run_turn(
             Err(CodexErr::Interrupted) => return Err(CodexErr::Interrupted),
             Err(CodexErr::EnvVar(var)) => return Err(CodexErr::EnvVar(var)),
             Err(e @ (CodexErr::UsageLimitReached(_) | CodexErr::UsageNotIncluded)) => {
+                if turn_context.client.rotate_api_key() {
+                    continue;
+                }
                 return Err(e);
             }
             Err(e) => {

--- a/codex-rs/core/src/config.rs
+++ b/codex-rs/core/src/config.rs
@@ -1251,6 +1251,8 @@ disable_response_storage = true
             name: "OpenAI using Chat Completions".to_string(),
             base_url: Some("https://api.openai.com/v1".to_string()),
             env_key: Some("OPENAI_API_KEY".to_string()),
+            api_keys: None,
+            api_key_index: 0,
             wire_api: crate::WireApi::Chat,
             env_key_instructions: None,
             query_params: None,

--- a/codex-rs/core/src/voice.rs
+++ b/codex-rs/core/src/voice.rs
@@ -43,6 +43,8 @@ impl ModelClient {
         let auth_mode = self.auth_manager.as_ref().and_then(|m| m.auth());
         let builder = self
             .provider
+            .lock()
+            .unwrap()
             .create_request_builder_for_path(&self.client, &auth_mode, "/audio/transcriptions")
             .await?;
 
@@ -71,6 +73,8 @@ impl ModelClient {
         let auth_mode = self.auth_manager.as_ref().and_then(|m| m.auth());
         let builder = self
             .provider
+            .lock()
+            .unwrap()
             .create_request_builder_for_path(&self.client, &auth_mode, "/audio/speech")
             .await?;
         let payload = json!({

--- a/codex-rs/core/tests/suite/client.rs
+++ b/codex-rs/core/tests/suite/client.rs
@@ -626,6 +626,8 @@ async fn azure_overrides_assign_properties_used_for_responses_url() {
         base_url: Some(format!("{}/openai", server.uri())),
         // Reuse the existing environment variable to avoid using unsafe code
         env_key: Some(existing_env_var_with_random_value.to_string()),
+        api_keys: None,
+        api_key_index: 0,
         query_params: Some(std::collections::HashMap::from([(
             "api-version".to_string(),
             "2025-04-01-preview".to_string(),
@@ -702,6 +704,8 @@ async fn env_var_overrides_loaded_auth() {
         base_url: Some(format!("{}/openai", server.uri())),
         // Reuse the existing environment variable to avoid using unsafe code
         env_key: Some(existing_env_var_with_random_value.to_string()),
+        api_keys: None,
+        api_key_index: 0,
         query_params: Some(std::collections::HashMap::from([(
             "api-version".to_string(),
             "2025-04-01-preview".to_string(),

--- a/codex-rs/core/tests/suite/stream_error_allows_next_turn.rs
+++ b/codex-rs/core/tests/suite/stream_error_allows_next_turn.rs
@@ -72,6 +72,8 @@ async fn continue_after_stream_error() {
         name: "mock-openai".into(),
         base_url: Some(format!("{}/v1", server.uri())),
         env_key: Some("PATH".into()),
+        api_keys: None,
+        api_key_index: 0,
         env_key_instructions: None,
         wire_api: WireApi::Responses,
         query_params: None,

--- a/codex-rs/core/tests/suite/stream_no_completed.rs
+++ b/codex-rs/core/tests/suite/stream_no_completed.rs
@@ -78,6 +78,8 @@ async fn retries_on_early_close() {
         // ModelClient will return an error if the environment variable for the
         // provider is not set.
         env_key: Some("PATH".into()),
+        api_keys: None,
+        api_key_index: 0,
         env_key_instructions: None,
         wire_api: codex_core::WireApi::Responses,
         query_params: None,

--- a/docs/config.md
+++ b/docs/config.md
@@ -87,6 +87,11 @@ base_url = "https://api.openai.com/v1"
 # using Codex with this provider. The value of the environment variable must be
 # non-empty and will be used in the `Bearer TOKEN` HTTP header for the POST request.
 env_key = "OPENAI_API_KEY"
+# Alternatively, provide a list of API keys directly. Codex will rotate through
+# these keys when usage limits are hit.
+# api_keys = ["KEY_ONE", "KEY_TWO"]
+# Index of the current key (defaults to 0). Codex updates this automatically when rotating.
+# api_key_index = 0
 # Valid values for wire_api are "chat" and "responses". Defaults to "chat" if omitted.
 wire_api = "chat"
 # If necessary, extra query params that need to be added to the URL.


### PR DESCRIPTION
## Summary
- allow model providers to hold multiple API keys and rotate automatically
- expose client helpers to rotate or reset keys when usage limits hit
- document multi-key configuration for providers in `config.toml`

## Testing
- `cargo test -p codex-core`


------
https://chatgpt.com/codex/tasks/task_b_68b1d17f45948329a8906a267a371168