### PR TITLE
feat: add TCP bridge server/client binaries for remote Codex sessions

### DIFF
--- a/codex-rs/Cargo.lock
+++ b/codex-rs/Cargo.lock
@@ -897,6 +897,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "codex-bridge"
+version = "0.0.0"
+dependencies = [
+ "anyhow",
+ "clap",
+ "codex-common",
+ "codex-core",
+ "codex-login",
+ "serde_json",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "codex-chatgpt"
 version = "0.0.0"
 dependencies = [

--- a/codex-rs/Cargo.toml
+++ b/codex-rs/Cargo.toml
@@ -4,6 +4,7 @@ members = [
     "ansi-escape",
     "apply-patch",
     "arg0",
+    "bridge",
     "cli",
     "common",
     "core",

--- a/codex-rs/bridge/Cargo.toml
+++ b/codex-rs/bridge/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "codex-bridge"
+version.workspace = true
+edition.workspace = true
+
+[[bin]]
+name = "codex-server"
+path = "src/server.rs"
+
+[[bin]]
+name = "codex-client"
+path = "src/client.rs"
+
+[dependencies]
+anyhow = "1"
+clap = { version = "4", features = ["derive"] }
+codex-common = { path = "../common", features = ["cli"] }
+codex-core = { path = "../core" }
+codex-login = { path = "../login" }
+serde_json = "1"
+tokio = { version = "1", features = ["io-std", "macros", "net", "rt-multi-thread", "signal"] }
+tracing = "0.1.41"
+tracing-subscriber = "0.3.19"
+
+[lints]
+workspace = true

--- a/codex-rs/bridge/src/client.rs
+++ b/codex-rs/bridge/src/client.rs
@@ -1,0 +1,73 @@
+use clap::Parser;
+use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+use tokio::net::TcpStream;
+use tokio::signal;
+use tracing::{error, info};
+
+/// Connect to a remote Codex server over TCP and proxy stdin/stdout.
+#[derive(Debug, Parser)]
+pub struct ClientCli {
+    /// Address of the Codex server
+    #[clap(long, default_value = "127.0.0.1:3030")]
+    addr: String,
+}
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    let cli = ClientCli::parse();
+    run_main(cli).await
+}
+
+async fn run_main(opts: ClientCli) -> anyhow::Result<()> {
+    tracing_subscriber::fmt()
+        .with_writer(std::io::stderr)
+        .init();
+
+    let stream = TcpStream::connect(&opts.addr).await?;
+    info!("connected to {}", &opts.addr);
+    let (read_half, mut write_half) = stream.into_split();
+    let reader = BufReader::new(read_half);
+
+    let sq = async {
+        let stdin = BufReader::new(tokio::io::stdin());
+        let mut lines = stdin.lines();
+        loop {
+            let line = tokio::select! {
+                _ = signal::ctrl_c() => break,
+                res = lines.next_line() => res,
+            };
+            match line {
+                Ok(Some(line)) => {
+                    if write_half.write_all(line.as_bytes()).await.is_err() {
+                        break;
+                    }
+                    if write_half.write_all(b"\n").await.is_err() {
+                        break;
+                    }
+                }
+                _ => break,
+            }
+        }
+    };
+
+    let eq = async move {
+        let mut lines = reader.lines();
+        loop {
+            let line = tokio::select! {
+                _ = signal::ctrl_c() => break,
+                res = lines.next_line() => res,
+            };
+            match line {
+                Ok(Some(line)) => println!("{line}"),
+                Ok(None) => break,
+                Err(e) => {
+                    error!("{e:#}");
+                    break;
+                }
+            }
+        }
+    };
+
+    tokio::join!(sq, eq);
+    Ok(())
+}

--- a/codex-rs/bridge/src/lib.rs
+++ b/codex-rs/bridge/src/lib.rs
@@ -1,0 +1,1 @@
+// Placeholder library for codex-bridge

--- a/codex-rs/bridge/src/server.rs
+++ b/codex-rs/bridge/src/server.rs
@@ -1,0 +1,144 @@
+use std::sync::Arc;
+
+use clap::Parser;
+use codex_common::CliConfigOverrides;
+use codex_core::ConversationManager;
+use codex_core::NewConversation;
+use codex_core::config::Config;
+use codex_core::config::ConfigOverrides;
+use codex_core::protocol::{Event, EventMsg, Submission};
+use codex_login::AuthManager;
+use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+use tokio::net::{TcpListener, TcpStream};
+use tokio::signal;
+use tracing::{error, info};
+
+/// Run Codex as a TCP server using the JSON protocol.
+#[derive(Debug, Parser)]
+pub struct ServerCli {
+    #[clap(flatten)]
+    config_overrides: CliConfigOverrides,
+
+    /// Address to bind the server to
+    #[clap(long, default_value = "127.0.0.1:3030")]
+    bind: String,
+}
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    let cli = ServerCli::parse();
+    run_main(cli).await
+}
+
+async fn run_main(opts: ServerCli) -> anyhow::Result<()> {
+    tracing_subscriber::fmt()
+        .with_writer(std::io::stderr)
+        .init();
+
+    let overrides_vec = opts
+        .config_overrides
+        .parse_overrides()
+        .map_err(anyhow::Error::msg)?;
+    let config = Config::load_with_cli_overrides(overrides_vec, ConfigOverrides::default())?;
+    let auth = AuthManager::shared(config.codex_home.clone(), config.preferred_auth_method);
+    let conversation_manager = Arc::new(ConversationManager::new(auth));
+
+    let listener = TcpListener::bind(&opts.bind).await?;
+    info!("listening on {}", &opts.bind);
+
+    loop {
+        let (stream, addr) = listener.accept().await?;
+        let cm = conversation_manager.clone();
+        let cfg = config.clone();
+        tokio::spawn(async move {
+            info!("client connected from {addr}");
+            if let Err(e) = handle_connection(stream, cm, cfg).await {
+                error!("connection error: {e:#}");
+            }
+            info!("client {addr} disconnected");
+        });
+    }
+}
+
+async fn handle_connection(
+    stream: TcpStream,
+    conversation_manager: Arc<ConversationManager>,
+    config: Config,
+) -> anyhow::Result<()> {
+    let NewConversation {
+        conversation,
+        session_configured,
+        ..
+    } = conversation_manager.new_conversation(config).await?;
+
+    let synthetic = Event {
+        id: String::new(),
+        msg: EventMsg::SessionConfigured(session_configured),
+    };
+
+    let (read_half, mut write_half) = stream.into_split();
+    let line = serde_json::to_string(&synthetic)?;
+    write_half.write_all(line.as_bytes()).await?;
+    write_half.write_all(b"\n").await?;
+
+    let reader = BufReader::new(read_half);
+
+    let sq = {
+        let conversation = conversation.clone();
+        async move {
+            let mut lines = reader.lines();
+            loop {
+                let line = tokio::select! {
+                    _ = signal::ctrl_c() => { break; },
+                    res = lines.next_line() => res,
+                };
+
+                match line {
+                    Ok(Some(line)) => {
+                        if line.trim().is_empty() {
+                            continue;
+                        }
+                        match serde_json::from_str::<Submission>(&line) {
+                            Ok(sub) => {
+                                if let Err(e) = conversation.submit_with_id(sub).await {
+                                    error!("{e:#}");
+                                    break;
+                                }
+                            }
+                            Err(e) => error!("invalid submission: {e}"),
+                        }
+                    }
+                    _ => break,
+                }
+            }
+        }
+    };
+
+    let eq = async move {
+        loop {
+            let event = tokio::select! {
+                _ = signal::ctrl_c() => break,
+                ev = conversation.next_event() => ev,
+            };
+            match event {
+                Ok(event) => {
+                    if let Ok(s) = serde_json::to_string(&event) {
+                        if write_half.write_all(s.as_bytes()).await.is_err() {
+                            break;
+                        }
+                        if write_half.write_all(b"\n").await.is_err() {
+                            break;
+                        }
+                    }
+                }
+                Err(e) => {
+                    error!("{e:#}");
+                    break;
+                }
+            }
+        }
+    };
+
+    tokio::join!(sq, eq);
+    Ok(())
+}


### PR DESCRIPTION
## Summary
- add `codex-bridge` crate with TCP server and client binaries
- enable running Codex protocol over the network
- register bridge crate in workspace

## Testing
- `cargo fmt --all`
- `cargo test -p codex-bridge`


------
https://chatgpt.com/codex/tasks/task_b_68b28925543483298ad7f458f6b68377