### PR TITLE
feat: add network server and client binaries

### DIFF
--- a/codex-rs/Cargo.lock
+++ b/codex-rs/Cargo.lock
@@ -936,6 +936,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "codex-client"
+version = "0.0.0"
+dependencies = [
+ "anyhow",
+ "clap",
+ "codex-core",
+ "serde_json",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "codex-common"
 version = "0.0.0"
 dependencies = [
@@ -1194,6 +1207,21 @@ dependencies = [
  "clap",
  "codex-protocol",
  "ts-rs",
+]
+
+[[package]]
+name = "codex-server"
+version = "0.0.0"
+dependencies = [
+ "anyhow",
+ "clap",
+ "codex-common",
+ "codex-core",
+ "codex-login",
+ "serde_json",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/codex-rs/Cargo.toml
+++ b/codex-rs/Cargo.toml
@@ -18,6 +18,8 @@ members = [
     "ollama",
     "protocol",
     "protocol-ts",
+    "server",
+    "client",
     "tui",
 ]
 resolver = "2"

--- a/codex-rs/client/Cargo.toml
+++ b/codex-rs/client/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "codex-client"
+version = { workspace = true }
+edition = "2024"
+
+[[bin]]
+name = "codex-client"
+path = "src/main.rs"
+
+[lints]
+workspace = true
+
+[dependencies]
+anyhow = "1"
+clap = { version = "4", features = ["derive"] }
+codex-core = { path = "../core" }
+serde_json = "1"
+tokio = { version = "1", features = ["macros", "net", "io-util", "rt-multi-thread", "signal"] }
+tracing = "0.1"
+tracing-subscriber = "0.3"

--- a/codex-rs/client/src/main.rs
+++ b/codex-rs/client/src/main.rs
@@ -1,0 +1,62 @@
+use std::net::SocketAddr;
+
+use clap::Parser;
+use codex_core::protocol::Submission;
+use tokio::io::AsyncBufReadExt;
+use tokio::io::AsyncWriteExt;
+use tokio::io::BufReader;
+use tokio::net::TcpStream;
+
+#[derive(Debug, Parser)]
+struct ClientCli {
+    #[arg(long, default_value = "127.0.0.1:7878")]
+    connect: SocketAddr,
+}
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    tracing_subscriber::fmt()
+        .with_writer(std::io::stderr)
+        .init();
+
+    let cli = ClientCli::parse();
+    let stream = TcpStream::connect(cli.connect).await?;
+    let (read_half, mut write_half) = stream.into_split();
+    let mut reader = BufReader::new(read_half).lines();
+
+    // Task to forward stdin to the server
+    let write_task = tokio::spawn(async move {
+        let stdin = BufReader::new(tokio::io::stdin());
+        let mut lines = stdin.lines();
+        while let Ok(Some(line)) = lines.next_line().await {
+            if line.trim().is_empty() {
+                continue;
+            }
+            match serde_json::from_str::<Submission>(&line) {
+                Ok(sub) => {
+                    let s = serde_json::to_string(&sub).unwrap();
+                    if write_half.write_all(s.as_bytes()).await.is_err() {
+                        break;
+                    }
+                    if write_half.write_all(b"\n").await.is_err() {
+                        break;
+                    }
+                    if write_half.flush().await.is_err() {
+                        break;
+                    }
+                }
+                Err(e) => eprintln!("invalid submission: {e}"),
+            }
+        }
+    });
+
+    // Task to print events from the server
+    let read_task = tokio::spawn(async move {
+        while let Ok(Some(line)) = reader.next_line().await {
+            println!("{}", line);
+        }
+    });
+
+    let _ = tokio::join!(write_task, read_task);
+    Ok(())
+}

--- a/codex-rs/server/Cargo.toml
+++ b/codex-rs/server/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "codex-server"
+version = { workspace = true }
+edition = "2024"
+
+[[bin]]
+name = "codex-server"
+path = "src/main.rs"
+
+[lints]
+workspace = true
+
+[dependencies]
+anyhow = "1"
+clap = { version = "4", features = ["derive"] }
+codex-common = { path = "../common", features = ["cli"] }
+codex-core = { path = "../core" }
+codex-login = { path = "../login" }
+serde_json = "1"
+tokio = { version = "1", features = ["macros", "net", "io-util", "rt-multi-thread", "signal"] }
+tracing = "0.1"
+tracing-subscriber = "0.3"

--- a/codex-rs/server/src/main.rs
+++ b/codex-rs/server/src/main.rs
@@ -1,0 +1,134 @@
+use std::net::SocketAddr;
+use std::sync::Arc;
+
+use anyhow::Context;
+use clap::Parser;
+use codex_common::CliConfigOverrides;
+use codex_core::ConversationManager;
+use codex_core::NewConversation;
+use codex_core::config::Config;
+use codex_core::config::ConfigOverrides;
+use codex_core::protocol::Event;
+use codex_core::protocol::EventMsg;
+use codex_core::protocol::Submission;
+use codex_login::AuthManager;
+use tokio::io::AsyncBufReadExt;
+use tokio::io::AsyncWriteExt;
+use tokio::io::BufReader;
+use tokio::net::TcpListener;
+use tokio::net::TcpStream;
+use tracing::error;
+use tracing::info;
+
+#[derive(Debug, Parser)]
+struct ServerCli {
+    #[arg(long, default_value = "127.0.0.1:7878")]
+    listen: SocketAddr,
+
+    #[clap(flatten)]
+    config_overrides: CliConfigOverrides,
+}
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    tracing_subscriber::fmt()
+        .with_writer(std::io::stderr)
+        .init();
+
+    let cli = ServerCli::parse();
+    let overrides_vec = cli
+        .config_overrides
+        .parse_overrides()
+        .map_err(anyhow::Error::msg)?;
+    let config = Config::load_with_cli_overrides(overrides_vec, ConfigOverrides::default())?;
+
+    let listener = TcpListener::bind(cli.listen)
+        .await
+        .context("binding listen address")?;
+    let auth_manager = AuthManager::shared(config.codex_home.clone(), config.preferred_auth_method);
+    let manager = Arc::new(ConversationManager::new(auth_manager));
+
+    loop {
+        let (stream, addr) = listener.accept().await?;
+        info!(?addr, "accepted connection");
+        let manager = Arc::clone(&manager);
+        let config = config.clone();
+        tokio::spawn(async move {
+            if let Err(e) = handle_connection(stream, manager, config).await {
+                error!("connection error: {e:#}");
+            }
+        });
+    }
+}
+
+async fn handle_connection(
+    stream: TcpStream,
+    manager: Arc<ConversationManager>,
+    config: Config,
+) -> anyhow::Result<()> {
+    let (read_half, mut write_half) = stream.into_split();
+    let mut reader = BufReader::new(read_half).lines();
+
+    let NewConversation {
+        conversation,
+        session_configured,
+        ..
+    } = manager.new_conversation(config).await?;
+
+    let init_event = Event {
+        id: String::new(),
+        msg: EventMsg::SessionConfigured(session_configured),
+    };
+    let init_str = serde_json::to_string(&init_event)?;
+    write_half.write_all(init_str.as_bytes()).await?;
+    write_half.write_all(b"\n").await?;
+    write_half.flush().await?;
+
+    let conversation_read = conversation.clone();
+    let read_task = tokio::spawn(async move {
+        while let Ok(Some(line)) = reader.next_line().await {
+            let line = line.trim().to_string();
+            if line.is_empty() {
+                continue;
+            }
+            match serde_json::from_str::<Submission>(&line) {
+                Ok(sub) => {
+                    if let Err(e) = conversation_read.submit_with_id(sub).await {
+                        error!("{e:#}");
+                        break;
+                    }
+                }
+                Err(e) => error!("invalid submission: {e}"),
+            }
+        }
+    });
+
+    let mut writer = write_half;
+    let event_task = tokio::spawn(async move {
+        loop {
+            match conversation.next_event().await {
+                Ok(ev) => match serde_json::to_string(&ev) {
+                    Ok(s) => {
+                        if writer.write_all(s.as_bytes()).await.is_err() {
+                            break;
+                        }
+                        if writer.write_all(b"\n").await.is_err() {
+                            break;
+                        }
+                        if writer.flush().await.is_err() {
+                            break;
+                        }
+                    }
+                    Err(e) => error!("serialize event: {e}"),
+                },
+                Err(e) => {
+                    error!("{e:#}");
+                    break;
+                }
+            }
+        }
+    });
+
+    let _ = tokio::join!(read_task, event_task);
+    Ok(())
+}


### PR DESCRIPTION
## Summary
- add `codex-server` crate exposing Codex over TCP
- add `codex-client` crate to connect and relay submissions
- wire server and client into the Rust workspace

## Testing
- `just fmt`
- `cargo build -p codex-server -p codex-client`
- `cargo test -p codex-core`


------
https://chatgpt.com/codex/tasks/task_b_68b28925543483298ad7f458f6b68377