### PR TITLE
fix: ensure omni-bridge tests compile

### DIFF
--- a/omni-bridge/Cargo.toml
+++ b/omni-bridge/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [features]
-default = []
+default = ["openai", "anthropic"]
 openai = ["reqwest", "tokio"]
 anthropic = ["reqwest", "tokio"]
 gemini = ["reqwest", "tokio"]
@@ -18,3 +18,5 @@ async-trait = "0.1"
 bitflags = "2"
 tokio = { version = "1", features = ["macros", "rt-multi-thread"], optional = true }
 reqwest = { version = "0.12", features = ["json", "stream"], optional = true }
+
+[workspace]


### PR DESCRIPTION
## Summary
- enable OpenAI and Anthropic adapters by default in omni-bridge
- mark omni-bridge as its own workspace so it builds outside the root workspace

## Testing
- `cargo test --manifest-path omni-bridge/Cargo.toml`


------
https://chatgpt.com/codex/tasks/task_b_68b563b0a6888329861c89cfcea8cb3d