### PR TITLE
test: guard Windows-specific path normalization test

### DIFF
--- a/codex-rs/tui/src/clipboard_paste.rs
+++ b/codex-rs/tui/src/clipboard_paste.rs
@@ -178,6 +178,7 @@ mod pasted_paths_tests {
         assert_eq!(result, PathBuf::from("/tmp/example.png"));
     }
 
+    #[cfg(windows)]
     #[test]
     fn normalize_file_url_windows() {
         let input = r"C:\Temp\example.png";


### PR DESCRIPTION
## Summary
- limit normalize_file_url_windows test to Windows

## Testing
- `cargo test -p codex-tui`
- `cargo insta pending-snapshots`


------
https://chatgpt.com/codex/tasks/task_b_68b6b5594d18832980a3e262a9994fa1