### PR TITLE
feat: support configurable model capabilities

### DIFF
--- a/codex-rs/core/src/agents/builtin.rs
+++ b/codex-rs/core/src/agents/builtin.rs
@@ -9,7 +9,7 @@ use crate::codex::Codex;
 use crate::codex::CodexSpawnOk;
 use crate::config::Config;
 use crate::config::find_codex_home;
-use crate::model_family::find_family_for_model;
+use crate::model_family::{built_in_model_capabilities, find_family_for_model};
 use crate::protocol::EventMsg;
 use crate::protocol::InputItem;
 use crate::protocol::Op;
@@ -68,7 +68,7 @@ pub mod coding {
         if let Some(role_name) = role {
             if let Some(role) = base.model_roles.get(role_name) {
                 cfg.model = role.model.clone();
-                cfg.model_family = find_family_for_model(&cfg.model)
+                cfg.model_family = find_family_for_model(&cfg.model, built_in_model_capabilities())
                     .unwrap_or_else(|| base.model_family.clone());
                 if let Some(provider_id) = &role.provider {
                     cfg.model_provider_id = provider_id.clone();
@@ -262,8 +262,9 @@ pub mod rag {
         if let Some(role_name) = answer_model_role {
             if let Some(role) = ctx.config.model_roles.get(role_name) {
                 nested_cfg.model = role.model.clone();
-                nested_cfg.model_family = crate::model_family::find_family_for_model(&nested_cfg.model)
-                    .unwrap_or_else(|| ctx.config.model_family.clone());
+                nested_cfg.model_family =
+                    find_family_for_model(&nested_cfg.model, built_in_model_capabilities())
+                        .unwrap_or_else(|| ctx.config.model_family.clone());
                 if let Some(provider_id) = &role.provider {
                     nested_cfg.model_provider_id = provider_id.clone();
                     if let Some(info) = ctx.config.model_providers.get(provider_id) {

--- a/codex-rs/core/src/client_common.rs
+++ b/codex-rs/core/src/client_common.rs
@@ -189,7 +189,7 @@ impl Stream for ResponseStream {
 
 #[cfg(test)]
 mod tests {
-    use crate::model_family::find_family_for_model;
+    use crate::model_family::{built_in_model_capabilities, find_family_for_model};
 
     use super::*;
 
@@ -199,7 +199,8 @@ mod tests {
             ..Default::default()
         };
         let expected = format!("{BASE_INSTRUCTIONS}\n{APPLY_PATCH_TOOL_INSTRUCTIONS}");
-        let model_family = find_family_for_model("gpt-4.1").expect("known model slug");
+        let model_family =
+            find_family_for_model("gpt-4.1", built_in_model_capabilities()).expect("known model slug");
         let full = prompt.get_full_instructions(&model_family);
         assert_eq!(full, expected);
     }

--- a/codex-rs/core/src/codex.rs
+++ b/codex-rs/core/src/codex.rs
@@ -65,7 +65,7 @@ use crate::exec_env::create_env;
 use crate::math_tools;
 use crate::mcp_connection_manager::McpConnectionManager;
 use crate::mcp_tool_call::handle_mcp_tool_call;
-use crate::model_family::find_family_for_model;
+use crate::model_family::{built_in_model_capabilities, find_family_for_model};
 use crate::openai_model_info::get_model_info;
 use crate::openai_tools::ApplyPatchToolArgs;
 use crate::openai_tools::ToolsConfig;
@@ -1070,8 +1070,8 @@ async fn submission_loop(
 
                 // Effective model + family
                 let (effective_model, effective_family) = if let Some(m) = model {
-                    let fam =
-                        find_family_for_model(&m).unwrap_or_else(|| config.model_family.clone());
+                    let fam = find_family_for_model(&m, built_in_model_capabilities())
+                        .unwrap_or_else(|| config.model_family.clone());
                     (m, fam)
                 } else {
                     (prev.client.get_model(), prev.client.get_model_family())
@@ -1168,7 +1168,7 @@ async fn submission_loop(
                     let auth_manager = turn_context.client.get_auth_manager();
 
                     // Derive a model family for the requested model; fall back to the session's.
-                    let model_family = find_family_for_model(&model)
+                    let model_family = find_family_for_model(&model, built_in_model_capabilities())
                         .unwrap_or_else(|| config.model_family.clone());
 
                     // Create a per‑turn Config clone with the requested model/family.

--- a/codex-rs/core/src/openai_tools.rs
+++ b/codex-rs/core/src/openai_tools.rs
@@ -855,7 +855,7 @@ fn create_invoke_dag_agent_tool() -> ResponsesApiTool {
 
 #[cfg(test)]
 mod tests {
-    use crate::model_family::find_family_for_model;
+    use crate::model_family::{built_in_model_capabilities, find_family_for_model};
     use mcp_types::ToolInputSchema;
     use pretty_assertions::assert_eq;
     use std::collections::BTreeMap;
@@ -888,8 +888,11 @@ mod tests {
 
     #[test]
     fn test_get_openai_tools() {
-        let model_family = find_family_for_model("codex-mini-latest")
-            .expect("codex-mini-latest should be a valid model family");
+        let model_family = find_family_for_model(
+            "codex-mini-latest",
+            built_in_model_capabilities(),
+        )
+        .expect("codex-mini-latest should be a valid model family");
         let config = ToolsConfig::new(&ToolsConfigParams {
             model_family: &model_family,
             approval_policy: AskForApproval::Never,
@@ -918,7 +921,8 @@ mod tests {
 
     #[test]
     fn test_get_openai_tools_default_shell() {
-        let model_family = find_family_for_model("o3").expect("o3 should be a valid model family");
+        let model_family =
+            find_family_for_model("o3", built_in_model_capabilities()).expect("o3 should be a valid model family");
         let config = ToolsConfig::new(&ToolsConfigParams {
             model_family: &model_family,
             approval_policy: AskForApproval::Never,
@@ -947,7 +951,8 @@ mod tests {
 
     #[test]
     fn test_get_openai_tools_mcp_tools() {
-        let model_family = find_family_for_model("o3").expect("o3 should be a valid model family");
+        let model_family =
+            find_family_for_model("o3", built_in_model_capabilities()).expect("o3 should be a valid model family");
         let config = ToolsConfig::new(&ToolsConfigParams {
             model_family: &model_family,
             approval_policy: AskForApproval::Never,
@@ -1055,7 +1060,8 @@ mod tests {
 
     #[test]
     fn test_get_openai_tools_mcp_tools_sorted_by_name() {
-        let model_family = find_family_for_model("o3").expect("o3 should be a valid model family");
+        let model_family =
+            find_family_for_model("o3", built_in_model_capabilities()).expect("o3 should be a valid model family");
         let config = ToolsConfig::new(&ToolsConfigParams {
             model_family: &model_family,
             approval_policy: AskForApproval::Never,
@@ -1135,7 +1141,8 @@ mod tests {
 
     #[test]
     fn test_mcp_tool_property_missing_type_defaults_to_string() {
-        let model_family = find_family_for_model("o3").expect("o3 should be a valid model family");
+        let model_family =
+            find_family_for_model("o3", built_in_model_capabilities()).expect("o3 should be a valid model family");
         let config = ToolsConfig::new(&ToolsConfigParams {
             model_family: &model_family,
             approval_policy: AskForApproval::Never,
@@ -1205,7 +1212,8 @@ mod tests {
 
     #[test]
     fn test_mcp_tool_integer_normalized_to_number() {
-        let model_family = find_family_for_model("o3").expect("o3 should be a valid model family");
+        let model_family =
+            find_family_for_model("o3", built_in_model_capabilities()).expect("o3 should be a valid model family");
         let config = ToolsConfig::new(&ToolsConfigParams {
             model_family: &model_family,
             approval_policy: AskForApproval::Never,
@@ -1270,7 +1278,8 @@ mod tests {
 
     #[test]
     fn test_mcp_tool_array_without_items_gets_default_string_items() {
-        let model_family = find_family_for_model("o3").expect("o3 should be a valid model family");
+        let model_family =
+            find_family_for_model("o3", built_in_model_capabilities()).expect("o3 should be a valid model family");
         let config = ToolsConfig::new(&ToolsConfigParams {
             model_family: &model_family,
             approval_policy: AskForApproval::Never,
@@ -1338,7 +1347,8 @@ mod tests {
 
     #[test]
     fn test_mcp_tool_anyof_defaults_to_string() {
-        let model_family = find_family_for_model("o3").expect("o3 should be a valid model family");
+        let model_family =
+            find_family_for_model("o3", built_in_model_capabilities()).expect("o3 should be a valid model family");
         let config = ToolsConfig::new(&ToolsConfigParams {
             model_family: &model_family,
             approval_policy: AskForApproval::Never,
@@ -1403,7 +1413,8 @@ mod tests {
 
     #[test]
     fn test_mcp_tool_additional_properties_schema_defaults_to_true() {
-        let model_family = find_family_for_model("o3").expect("o3 should be a valid model family");
+        let model_family =
+            find_family_for_model("o3", built_in_model_capabilities()).expect("o3 should be a valid model family");
         let config = ToolsConfig::new(&ToolsConfigParams {
             model_family: &model_family,
             approval_policy: AskForApproval::Never,

--- a/codex-rs/core/tests/suite/prompt_caching.rs
+++ b/codex-rs/core/tests/suite/prompt_caching.rs
@@ -3,7 +3,7 @@
 use codex_core::ConversationManager;
 use codex_core::ModelProviderInfo;
 use codex_core::built_in_model_providers;
-use codex_core::model_family::find_family_for_model;
+use codex_core::model_family::{built_in_model_capabilities, find_family_for_model};
 use codex_core::protocol::AskForApproval;
 use codex_core::protocol::EventMsg;
 use codex_core::protocol::InputItem;
@@ -75,7 +75,8 @@ async fn codex_mini_latest_tools() {
         ConversationManager::with_auth(CodexAuth::from_api_key("Test API Key"));
     config.include_apply_patch_tool = false;
     config.model = "codex-mini-latest".to_string();
-    config.model_family = find_family_for_model("codex-mini-latest").unwrap();
+    config.model_family =
+        find_family_for_model("codex-mini-latest", built_in_model_capabilities()).unwrap();
 
     let codex = conversation_manager
         .new_conversation(config)

--- a/codex-rs/ollama/src/lib.rs
+++ b/codex-rs/ollama/src/lib.rs
@@ -5,8 +5,7 @@ mod url;
 
 pub use client::OllamaClient;
 use codex_core::config::Config;
-use codex_core::model_family::ModelFamily;
-use codex_core::model_family::find_family_for_model;
+use codex_core::model_family::{built_in_model_capabilities, find_family_for_model, ModelFamily};
 pub use pull::CliProgressReporter;
 pub use pull::PullEvent;
 pub use pull::PullProgressReporter;
@@ -36,7 +35,8 @@ pub async fn ensure_oss_ready(config: &mut Config) -> std::io::Result<()> {
             {
                 tracing::info!("Using local Ollama model `{}`", first);
                 config.model = first.clone();
-                config.model_family = find_family_for_model(first).unwrap_or_else(|| ModelFamily {
+                config.model_family = find_family_for_model(first, built_in_model_capabilities())
+                    .unwrap_or_else(|| ModelFamily {
                     slug: first.clone(),
                     family: first.clone(),
                     needs_special_apply_patch_instructions: false,

--- a/docs/config.md
+++ b/docs/config.md
@@ -378,6 +378,40 @@ By default, `reasoning` is only set on requests to OpenAI models that are known 
 model_supports_reasoning_summaries = true
 ```
 
+## model_needs_special_apply_patch_instructions
+
+Force the inclusion of extra instructions describing the virtual `apply_patch` CLI for the configured model.
+
+```toml
+model_needs_special_apply_patch_instructions = true
+```
+
+## model_uses_local_shell_tool
+
+When set, the implicit `local_shell` tool is always available to the configured model.
+
+```toml
+model_uses_local_shell_tool = true
+```
+
+## model_apply_patch_tool_type
+
+Specify the preferred `apply_patch` tool call style for the configured model. Valid values are `"function"` and `"freeform"`.
+
+```toml
+model_apply_patch_tool_type = "function"
+```
+
+## model_capabilities
+
+Define capabilities for additional model slugs. These settings override built-in defaults.
+
+```toml
+[model_capabilities."gpt-4.1"]
+needs_special_apply_patch_instructions = true
+supports_reasoning_summaries = true
+```
+
 ## sandbox_mode
 
 Codex executes model-generated shell commands inside an OS-level sandbox.
@@ -747,6 +781,13 @@ auto_compact_tolerance_percent = 8
 | `projects.<path>.trust_level`                    | string             | Mark project/worktree as trusted (only `"trusted"` is recognized).                         |
 | `preferred_auth_method`                          | `chatgpt`          | `apikey`                                                                                   | Select default auth method (default: `chatgpt`). |
 | `tools.web_search`                               | boolean            | Enable web search tool (alias: `web_search_request`) (default: false).                     |
+| `model_needs_special_apply_patch_instructions`   | boolean            | Include extra `apply_patch` instructions.                     |
+| `model_uses_local_shell_tool`                    | boolean            | Expose implicit `local_shell` tool.                     |
+| `model_apply_patch_tool_type`                    | `function`/`freeform` | Preferred `apply_patch` tool call style.                     |
+| `model_capabilities.<slug>.needs_special_apply_patch_instructions` | boolean | Per-model `apply_patch` instructions.                     |
+| `model_capabilities.<slug>.supports_reasoning_summaries` | boolean | Per-model reasoning summaries toggle.                     |
+| `model_capabilities.<slug>.uses_local_shell_tool` | boolean | Per-model implicit `local_shell` tool.                     |
+| `model_capabilities.<slug>.apply_patch_tool_type` | `function`/`freeform` | Per-model `apply_patch` tool style.                     |
 
 ## model_roles
 


### PR DESCRIPTION
## Summary
- add `ModelCapabilities` struct and built-in capability map
- allow config to override model capabilities and add new top-level keys
- document new model capability settings

## Testing
- `cargo fmt`
- `cargo test -p codex-core`


------
https://chatgpt.com/codex/tasks/task_b_68bb061905a483299c7e523869289f37