### PR TITLE
feat(gui): add basic interactivity

### DIFF
--- a/codex-rs/Cargo.lock
+++ b/codex-rs/Cargo.lock
@@ -1299,6 +1299,7 @@ dependencies = [
  "codex-arg0",
  "codex-tui",
  "eframe",
+ "pretty_assertions",
 ]
 
 [[package]]

--- a/codex-rs/gui/Cargo.toml
+++ b/codex-rs/gui/Cargo.toml
@@ -20,3 +20,6 @@ clap = { version = "4", features = ["derive"] }
 codex-arg0 = { path = "../arg0" }
 codex-tui = { path = "../tui" }
 eframe = "0.27"
+
+[dev-dependencies]
+pretty_assertions = "1"


### PR DESCRIPTION
## Summary
- add GUI state management for sessions, notes, and messages
- wire up buttons to add sessions/notes and send messages
- cover new helpers with unit tests

## Testing
- `cargo fmt -p codex-gui`
- `cargo clippy -p codex-gui -- -D warnings` *(fails: compilation aborted)*
- `cargo test -p codex-gui` *(fails: compilation aborted)*

------
https://chatgpt.com/codex/tasks/task_b_68c74f20e51c832f8cc0aef0529f0dde